### PR TITLE
Separate authentication layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,8 +4,7 @@ import { Inter } from "next/font/google"
 import "./globals.css"
 import { ClerkProvider } from "@clerk/nextjs"
 import { ThemeProvider } from "@/components/theme-provider"
-import { AppSidebar } from "@/components/app-sidebar"
-import { SidebarProvider } from "@/components/ui/sidebar"
+import { AppLayout } from "@/components/app-layout"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -28,12 +27,7 @@ export default function RootLayout({
       <html lang="en">
         <body className={inter.className}>
           <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
-            <SidebarProvider>
-              <div className="flex min-h-screen">
-                <AppSidebar />
-                <div className="flex-1">{children}</div>
-              </div>
-            </SidebarProvider>
+            <AppLayout>{children}</AppLayout>
           </ThemeProvider>
         </body>
       </html>

--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -37,7 +37,7 @@ export default function SignInPage() {
                     footerActionLink: "text-slate-600 hover:text-slate-900",
                   },
                 }}
-                redirectUrl="/dashboard"
+                redirectUrl="/"
                 signUpUrl="/sign-up"
               />
             </div>

--- a/app/sign-up/[[...sign-up]]/page.tsx
+++ b/app/sign-up/[[...sign-up]]/page.tsx
@@ -37,7 +37,7 @@ export default function SignUpPage() {
                     footerActionLink: "text-slate-600 hover:text-slate-900",
                   },
                 }}
-                redirectUrl="/dashboard"
+                redirectUrl="/"
                 signInUrl="/sign-in"
               />
             </div>

--- a/components/app-layout.tsx
+++ b/components/app-layout.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import type React from "react"
+import { usePathname } from "next/navigation"
+import { SidebarProvider } from "@/components/ui/sidebar"
+import { AppSidebar } from "@/components/app-sidebar"
+
+interface AppLayoutProps {
+  children: React.ReactNode
+}
+
+export function AppLayout({ children }: AppLayoutProps) {
+  const pathname = usePathname()
+  const isAuthRoute = pathname.startsWith("/sign-in") || pathname.startsWith("/sign-up")
+
+  if (isAuthRoute) {
+    return <>{children}</>
+  }
+
+  return (
+    <SidebarProvider>
+      <div className="flex min-h-screen">
+        <AppSidebar />
+        <div className="flex-1">{children}</div>
+      </div>
+    </SidebarProvider>
+  )
+}


### PR DESCRIPTION
## Summary
- add AppLayout component to handle sidebar logic
- show sidebar only when not on auth pages
- update sign in/up redirect to dashboard root

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840141ded54832583d2bcc6f4a0ed1e